### PR TITLE
Help developers to test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ resources
 
 # Example Site
 
+package.json
 package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,28 +1,27 @@
-# FrontLine Documentation
+# gatling.io/docs Theme
 
-Node.js dependencies:
+## Dev mode
 
-```
-npm install
-```
+### Quick (docker-compose)
 
-Running a local server:
-
-```
-npm run server
+```console
+docker-compose up
 ```
 
-Then, connect to http://localhost:1313
+Then, go to [http://localhost:1313](http://localhost:1313)
 
-Create a new page:
 
+### Local
+
+```console
+hugo mod npm pack
+cd exampleSite
+hugo server --buildDrafts
 ```
-npm run create docs/user/test/test.md
-```
 
-Make sure you have draft set to false in the page metadata, otherwise the page you created won't be displayed.
+Then, go to [http://localhost:1313](http://localhost:1313)
 
-### Page weight
+## Page weight
 
 The weight indicates which page comes first in the sidebar. We use this system: SBXX0 where:
 - S: corresponds to the sidenav section number (begins at 1)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.9"
+
+services:
+
+  hugo:
+    image: klakegg/hugo:0.82.0-ext-alpine
+    ports:
+     - 1313:1313
+    volumes:
+     - .:/src/gatling.io-doc-theme
+     - /src/gatling.io-doc-theme/resources/
+     - /src/gatling.io-doc-theme/node_modules/
+    environment:
+      - HUGO_ENV=development
+    working_dir: /src/gatling.io-doc-theme
+    entrypoint: "bash -c 'hugo mod npm pack && npm install && pwd && ls . && cd exampleSite && pwd && ls . && hugo server --buildDrafts'"


### PR DESCRIPTION
Motivation:
I don't want to install hugo (or build any golang for that matters) onto my
computer.

Modifications:
 * Create docker-compose configuration
 * Update README with docker-compose launch
 * Rewrite manual launch as well

Result:
Developers can easily develop.