### PR TITLE
Rework doc menu and navigation based on structure

### DIFF
--- a/exampleSite/content/oss/reference/3.4/_index.md
+++ b/exampleSite/content/oss/reference/3.4/_index.md
@@ -1,4 +1,5 @@
 ---
+menu: true
 cascade:
   version: 3.4
 ---

--- a/exampleSite/content/oss/reference/3.4/category-0/index.md
+++ b/exampleSite/content/oss/reference/3.4/category-0/index.md
@@ -1,0 +1,7 @@
+---
+title: "Part 0"
+date: 2021-04-23T05:19:27-04:00
+weight: 1
+---
+
+CONTENT

--- a/exampleSite/content/oss/reference/3.5/category-0/index.md
+++ b/exampleSite/content/oss/reference/3.5/category-0/index.md
@@ -1,0 +1,7 @@
+---
+title: "Part 0"
+date: 2021-04-23T05:19:27-04:00
+weight: 1
+---
+
+CONTENT

--- a/exampleSite/content/oss/reference/current/category-0/index.md
+++ b/exampleSite/content/oss/reference/current/category-0/index.md
@@ -1,0 +1,7 @@
+---
+title: "Category 0"
+date: 2021-04-23T05:19:27-04:00
+weight: 1
+---
+
+CONTENT

--- a/layouts/partials/main/docs-navigation.html
+++ b/layouts/partials/main/docs-navigation.html
@@ -1,27 +1,35 @@
 {{ if or .Prev .Next -}}
 	<div class="docs-navigation d-flex justify-content-between">
-	<!-- https://www.feliciano.tech/blog/custom-sort-hugo-single-pages/ -->
 
-	{{ $sectionPages := where site.RegularPages "Section" .Section -}}
-  {{ $pages :=  where $sectionPages ".Parent.Parent.File.Dir" "eq" .Parent.Parent.File.Dir }}
+  {{ $nestedCategoryEntries := eq (len .Parent.Sections) 0 }}
+  {{ $sectionPages := where site.RegularPages "Section" .Section -}}
 
-	{{ with $pages.Next . -}}
-		<a href="{{ .Permalink }}">
-			<div class="card my-1">
-				<div class="card-body py-2">
-					&larr; {{ .Title }}
-				</div>
-			</div>
-		</a>
-	{{ end -}}
-	{{ with $pages.Prev . -}}
-		<a class="ms-auto" href="{{ .Permalink }}">
-			<div class="card my-1">
-				<div class="card-body py-2">
-					{{ .Title }} &rarr;
-				</div>
-			</div>
-		</a>
-	{{ end -}}
+  {{ $pages := slice }}
+  {{ if $nestedCategoryEntries }}
+    {{ $pages = where $sectionPages ".Parent.Parent.File.Dir" "eq" .Parent.Parent.File.Dir }}
+    {{ $pages = append $pages (where $sectionPages ".Parent.File.Dir" "eq" .Parent.Parent.File.Dir) }}
+  {{ else }}
+    {{ $pages = where $sectionPages ".Parent.Parent.File.Dir" "eq" .Parent.File.Dir }}
+    {{ $pages = append $pages (where $sectionPages ".Parent.File.Dir" "eq" .Parent.File.Dir) }}
+  {{ end }}
+
+  {{ with $pages.Next . -}}
+    <a href="{{ .Permalink }}">
+      <div class="card my-1">
+        <div class="card-body py-2">
+          &larr; {{ .Title }}
+        </div>
+      </div>
+    </a>
+  {{ end -}}
+  {{ with $pages.Prev . -}}
+    <a class="ms-auto" href="{{ .Permalink }}">
+      <div class="card my-1">
+        <div class="card-body py-2">
+          {{ .Title }} &rarr;
+        </div>
+      </div>
+    </a>
+  {{ end -}}
 	</div>
 {{ end -}}

--- a/layouts/partials/sidebar/docs-menu.html
+++ b/layouts/partials/sidebar/docs-menu.html
@@ -3,17 +3,36 @@
 {{- $path := split .CurrentSection.File.Dir "/" -}}
 {{- $menu := printf "%s" (delimit (first 2 $path) "-") -}}
 
-{{ if isset .Site.Menus $menu -}}
-  {{ range (index .Site.Menus $menu) -}}
-    <h3>{{ .Name }}</h3>
-      {{ if .HasChildren -}}
-      <ul class="list-unstyled">
-        {{ range .Children -}}
-          {{- $active := or ($currentPage.IsMenuCurrent $menu .) ($currentPage.HasMenuCurrent $menu .) -}}
-          {{- $active = or $active (eq $currentPage.Section .Identifier) -}}
-          <li><a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a></li>
-        {{ end -}}
-      </ul>
+{{ $nestedCategoryEntries := eq (len .Parent.Sections) 0 }}
+{{ $sectionPages := where site.RegularPages "Section" .Section -}}
+
+{{ $pages := slice }}
+{{ if $nestedCategoryEntries }}
+  {{ $pages = where $sectionPages ".Parent.Parent.File.Dir" "eq" .Parent.Parent.File.Dir }}
+  {{ $pages = append $pages (where $sectionPages ".Parent.File.Dir" "eq" .Parent.Parent.File.Dir) }}
+{{ else }}
+  {{ $pages = where $sectionPages ".Parent.Parent.File.Dir" "eq" .Parent.File.Dir }}
+  {{ $pages = append $pages (where $sectionPages ".Parent.File.Dir" "eq" .Parent.File.Dir) }}
+{{ end }}
+
+{{ $menu := newScratch }}
+{{ $menuEntries := newScratch }}
+{{ range $pages }}
+  {{ $menu.Add .Parent.Title (slice .) }}
+  {{ $menuEntries.SetInMap "entries" .Parent.Title .Parent.URL }}
+{{ end }}
+
+{{ $entries := $menuEntries.Get "entries" }}
+{{ range $key, $value := $entries }}
+  <h3>
+    <a href="{{ $value | absURL }}">{{ $key }}</a>
+  </h3>
+  <ul class="list-unstyled">
+    {{ range $menu.Get $key }}
+      {{ $active := eq $currentPage . }}
+      <li>
+        <a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a>
+      </li>
     {{ end -}}
-  {{ end -}}
-{{ end -}}
+  </ul>
+{{ end }}

--- a/layouts/shortcodes/include-static.html
+++ b/layouts/shortcodes/include-static.html
@@ -1,0 +1,7 @@
+{{ $path := printf "**%s" (.Get 0) -}}
+{{ $param1 := index .Site.Data.variables (.Get 1) -}}
+{{ $param2 := index .Site.Data.variables (.Get 2) -}}
+{{ $param3 := index .Site.Data.variables (.Get 3) -}}
+{{ $param4 := index .Site.Data.variables (.Get 4) -}}
+{{ $page := .Page.Resources.GetMatch $path -}}
+{{ $page.Content | replaceRE "\\{param1\\}" $param1 | replaceRE "\\{param2\\}" $param2 | replaceRE "\\{param3\\}" $param3 | replaceRE "\\{param4\\}" $param4  -}}


### PR DESCRIPTION
**Motivation:**
Documentation is aggregated on `gatling.io-doc`, leading to conflicts on
menus front matter definition.

**Modifications:**
Based on project structure, infer menu entries and heading sections.
Use the same design for navigation on pages.