### PR TITLE
Sort menu and navigation entries by weight and category weight

### DIFF
--- a/exampleSite/content/cloud/reference/category-1/_index.md
+++ b/exampleSite/content/cloud/reference/category-1/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Category 1
+weight: 2
 ---

--- a/exampleSite/content/cloud/reference/category-2/_index.md
+++ b/exampleSite/content/cloud/reference/category-2/_index.md
@@ -1,3 +1,4 @@
 ---
 title: Category 2
+weight: 1
 ---

--- a/layouts/partials/main/docs-navigation.html
+++ b/layouts/partials/main/docs-navigation.html
@@ -13,7 +13,8 @@
     {{ $pages = append $pages (where $sectionPages ".Parent.File.Dir" "eq" .Parent.File.Dir) }}
   {{ end }}
 
-  {{ with $pages.Next . -}}
+  {{ $sortedPages := (sort (sort $pages ".Parent.Weight") "Weight") }}
+  {{ with $sortedPages.Next . -}}
     <a href="{{ .Permalink }}">
       <div class="card my-1">
         <div class="card-body py-2">
@@ -22,7 +23,7 @@
       </div>
     </a>
   {{ end -}}
-  {{ with $pages.Prev . -}}
+  {{ with $sortedPages.Prev . -}}
     <a class="ms-auto" href="{{ .Permalink }}">
       <div class="card my-1">
         <div class="card-body py-2">

--- a/layouts/partials/sidebar/docs-menu.html
+++ b/layouts/partials/sidebar/docs-menu.html
@@ -16,19 +16,20 @@
 {{ end }}
 
 {{ $menu := newScratch }}
-{{ $menuEntries := newScratch }}
+{{ $menuEntries := slice }}
+
 {{ range $pages }}
-  {{ $menu.Add .Parent.Title (slice .) }}
-  {{ $menuEntries.SetInMap "entries" .Parent.Title .Parent.URL }}
+  {{ $title := .Parent.Title }}
+  {{ $menu.Add $title (slice .) }}
+  {{ $menuEntries = $menuEntries | append (dict "title" $title "weight" .Parent.Weight "url" .Parent.Permalink) }}
 {{ end }}
 
-{{ $entries := $menuEntries.Get "entries" }}
-{{ range $key, $value := $entries }}
+{{ range sort (uniq $menuEntries) "weight" }}
   <h3>
-    <a href="{{ $value | absURL }}">{{ $key }}</a>
+    <a href="{{ .url | absURL }}">{{ .title }}</a>
   </h3>
   <ul class="list-unstyled">
-    {{ range $menu.Get $key }}
+    {{ range ($menu.Get .title).ByWeight }}
       {{ $active := eq $currentPage . }}
       <li>
         <a class="docs-link{{ if $active }} active{{ end }}" href="{{ .URL | absURL }}">{{ .Name }}</a>


### PR DESCRIPTION
**Motivation:**
Order should not be based on title only

**Modifications:**
* Use a slice instead of a map in docs-menu category accumulation
* Sort categories, then entries on menu
* Sort by parent weight then current weight on navigation

**Result:**
* Navigation and menu ordered by independant weight