### PR TITLE
Fix title generation

### DIFF
--- a/exampleSite/content/enterprise/cloud/_index.md
+++ b/exampleSite/content/enterprise/cloud/_index.md
@@ -1,4 +1,5 @@
 ---
+title: Cloud
 cascade:
   docsRepo:
     url: https://github.com/gatling/gatling.io-doc-theme/blob/main/exampleSite/content/cloud

--- a/exampleSite/content/gatling/_index.md
+++ b/exampleSite/content/gatling/_index.md
@@ -1,5 +1,5 @@
 ---
-title: "Home"
+title: "Gatling"
 lead: ""
 date: 2021-04-20T18:30:56+02:00
 lastmod: 2021-04-20T18:30:56+02:00

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,21 +7,21 @@
   {{ else if eq .Kind "page" -}}
     {{- $current := . -}}
     {{ range .Site.Menus.main -}}
-      {{ if hasPrefix $current.File.Dir .URL -}}
-        {{ $current.Scratch.Set "identifier" .Identifier -}}
+      {{ if hasPrefix $current.File.Dir .ConfiguredURL -}}
+        {{ $current.Scratch.Set "menu" . -}}
       {{ end }}
     {{ end }}
-    {{ .Scratch.Set "class" (or (.Scratch.Get "identifier") .Type) -}}
+    {{ .Scratch.Set "class" (or (.Scratch.Get "menu").Identifier .Type) -}}
     {{ .Scratch.Add "class" " single" -}}
   {{ else -}}
     {{- $current := . -}}
     {{ range .Site.Menus.main -}}
-      {{ if hasPrefix $current.File.Dir .URL -}}
-        {{ $current.Scratch.Set "identifier" .Identifier -}}
+      {{ if hasPrefix $current.File.Dir .ConfiguredURL -}}
+        {{ $current.Scratch.Set "menu" . -}}
       {{ end }}
     {{ end }}
     {{ .Scratch.Set "class" .Type -}}
-    {{ .Scratch.Add "class" (printf " %s" (.Scratch.Get "identifier")) -}}
+    {{ .Scratch.Add "class" (printf " %s" (.Scratch.Get "menu").Identifier ) -}}
     {{ .Scratch.Add "class" " list" -}}
   {{ end -}}
   {{ partial "head/head.html" . }}

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -10,22 +10,28 @@
   {{ end -}}
 {{ end -}}
 
-{{ if .IsHome -}}
-  <title>{{ .Site.Params.Title }}</title>
-{{ else -}}
-  {{ $section := .Site.GetPage "section" .Section }}
-  {{ if or (eq .Title "") (eq .Title $section.Title) -}}
-    <title>{{ $section.Title }}</title>
-  {{ else -}}
-    {{ $identifier := .Scratch.Get "identifier" -}}
-    {{ $subsection := .Site.GetPage "page" $identifier -}}
-    {{ if eq .Title $subsection.Title -}}
-      <title>{{ .Title }}</title>
-    {{ else -}}
-      <title>{{ $subsection.Title }} {{ .Site.Params.titleSeparator }} {{ .Title }}</title>
-    {{ end -}}
-  {{ end -}}
-{{ end -}}
+{{/*
+  Home page  : site title
+  if section : section title
+  if page    : section title - page title
+*/}}
+<title>
+{{- if .IsHome -}}
+  {{ .Site.Params.Title }}
+{{- else -}}
+  {{ $menu := (.Scratch.Get "menu") }}
+  {{- if $menu -}}
+    {{- $section := (.Site.GetPage $menu.ConfiguredURL) -}}
+    {{- $section.Title -}}
+    {{- if (and (ne .Page $section) (ne .Title "")) -}}
+        {{- printf " - %s" .Title -}}
+    {{- end -}}
+  {{- else -}}
+    {{- .Title -}}
+  {{- end -}}
+{{- end -}}
+</title>
+
 
 {{ with .Description -}}
   <meta name="description" content="{{ . }}">


### PR DESCRIPTION
**Motivation:**
Does not work on frontline-cloud-doc

**Modification:**
Use ConfiguredURL instead of identifier to match menu entry, and add
menu entry in scratch for SEO title configuration