### PR TITLE
Fix edit page links, close MISC-220

### DIFF
--- a/layouts/partials/main/edit-page.html
+++ b/layouts/partials/main/edit-page.html
@@ -1,5 +1,7 @@
 <p class="edit-page">
-  <a href="{{ .Params.docsRepo.url }}/{{ strings.TrimPrefix .Params.docsRepo.rel .File.Path }}">
+  {{- $editPage := strings.TrimPrefix .Params.docsRepo.rel .File.Path -}}
+  {{- $editPage = replace $editPage .Params.version "current" 1 -}}
+  <a href="{{ .Params.docsRepo.url }}{{ $editPage }}">
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit-2">
       <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
     </svg>


### PR DESCRIPTION
Motivation:

- Links to edit page on bottom isn't set up properly
- The page path is actually different from the repository layout, as url
  might contain a version but in the repository the path will ALWAYS
  contain "current" regardless of the branch

Modification:

- Replace version in subpath with current
- Remove extra slash in front of the file path