### PR TITLE
fix: handle properly code-toggle and include-code tabs, closes MISC-383

### DIFF
--- a/assets/js/tabs.ts
+++ b/assets/js/tabs.ts
@@ -1,18 +1,9 @@
-const tabs = document.querySelectorAll("[data-toggle-tab]");
-const panes = document.querySelectorAll("[data-pane]");
+const DATA_TOGGLE_KEY = "data-toggle-key";
+const DATA_TOGGLE_VALUE = "data-toggle-value";
 
-const toggleAllTabsOnClick = (event, targetKey) => {
-  const initializing = targetKey !== undefined;
+const ACTIVE_CLASS = "active";
 
-  let targetValue;
-  if (event.target) {
-    event.preventDefault();
-    targetKey = event.currentTarget.getAttribute("data-toggle-key");
-    targetValue = event.currentTarget.getAttribute("data-toggle-tab");
-  } else {
-    targetValue = event;
-  }
-
+const toggleAllTabsOnClick = (targetKey, targetValue, initializing) => {
   // We store the config language selected in users' localStorage
   localStorage.setItem(targetKey, targetValue);
   if (!initializing && targetKey === "language") {
@@ -22,26 +13,23 @@ const toggleAllTabsOnClick = (event, targetKey) => {
     });
   }
 
-  const selectedTabs = document.querySelectorAll(
-    "[data-toggle-tab='" + targetValue + "']"
-  );
-  const selectedPanes = document.querySelectorAll(
-    "[data-pane='" + targetValue + "']"
-  );
-
-  for (let i = 0; i < tabs.length; i++) {
-    tabs[i].classList.remove("active");
-    panes[i].classList.remove("active");
-  }
-
-  for (let i = 0; i < selectedTabs.length; i++) {
-    selectedTabs[i].classList.add("active");
-    selectedPanes[i].classList.add("active");
-  }
+  document.querySelectorAll(`[${DATA_TOGGLE_KEY}='${targetKey}']`).forEach(selected => {
+    selected.classList.remove(ACTIVE_CLASS);
+    if (selected.getAttribute(DATA_TOGGLE_VALUE) === targetValue) {
+      selected.classList.add(ACTIVE_CLASS);
+    }
+  })
 };
 
-for (const tab of tabs) {
-  tab.addEventListener("click", toggleAllTabsOnClick);
+for (const tab of document.querySelectorAll(`button[${DATA_TOGGLE_KEY}]`)) {
+  tab.addEventListener("click", (event) => {
+    event.preventDefault();
+    toggleAllTabsOnClick(
+      event.currentTarget.getAttribute(DATA_TOGGLE_KEY),
+      event.currentTarget.getAttribute(DATA_TOGGLE_VALUE),
+      false
+    )
+  });
 }
 
 // Clean up old items
@@ -49,19 +37,13 @@ if (localStorage.hasOwnProperty("configLangPref")) {
   localStorage.removeItem("configLangPref");
 }
 
-// Set defaults
-for (const [key, value] of [
-  ["build-tool", "bundle"],
-  ["language", "java"],
-]) {
-  if (!localStorage.hasOwnProperty(key)) {
-    localStorage.setItem(key, value);
-  }
+const DEFAULTS_TABS = {
+  "build-tool": "maven",
+  "language": "java"
 }
 
-// Upon page load, if user has a preferred language or build-tool in its localStorage, tabs are set to it.
-for (const key of ["build-tool", "language"]) {
-  if (localStorage.hasOwnProperty(key)) {
-    toggleAllTabsOnClick(localStorage.getItem(key), key);
-  }
+for (const [key, defaultValue] of Object.entries(DEFAULTS_TABS)) {
+  const value = localStorage.hasOwnProperty(key) ? localStorage.getItem(key) : defaultValue;
+  toggleAllTabsOnClick(key, value, true);
 }
+

--- a/exampleSite/content/enterprise/cloud/reference/category-1/part-1/code/ComputerDatabaseSampleJava.java
+++ b/exampleSite/content/enterprise/cloud/reference/category-1/part-1/code/ComputerDatabaseSampleJava.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gatling.javaapi.core.*;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+
+class ComputerDatabaseSampleJava {
+
+  ScenarioBuilder computerDbScn = scenario("Computer Scenario")
+    //#print-session-value
+    .exec(session -> {
+      System.out.println(session.getString("addComputer"));
+      return session;
+    })
+    //#print-session-value
+    ;
+}

--- a/exampleSite/content/enterprise/cloud/reference/category-1/part-1/code/ComputerDatabaseSampleKotlin.kt
+++ b/exampleSite/content/enterprise/cloud/reference/category-1/part-1/code/ComputerDatabaseSampleKotlin.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gatling.javaapi.core.CoreDsl.*;
+
+class ComputerDatabaseSampleKotlin {
+
+  val computerDbScn = scenario("Computer Scenario")
+    //#print-session-value
+    .exec { session ->
+      println(session.getString("addComputer"))
+      session
+    }
+    //#print-session-value
+}

--- a/exampleSite/content/enterprise/cloud/reference/category-1/part-1/code/ComputerDatabaseSampleScala.scala
+++ b/exampleSite/content/enterprise/cloud/reference/category-1/part-1/code/ComputerDatabaseSampleScala.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2011-2021 GatlingCorp (https://gatling.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.gatling.core.Predef._
+
+class ComputerDatabaseSampleScala {
+
+  val computerDbScn = scenario("Computer Scenario")
+    //#print-session-value
+    .exec { session =>
+      println(session("addComputer").as[String])
+      session
+    }
+    //#print-session-value
+}

--- a/exampleSite/content/enterprise/cloud/reference/category-1/part-1/index.md
+++ b/exampleSite/content/enterprise/cloud/reference/category-1/part-1/index.md
@@ -4,3 +4,14 @@ date: 2021-04-23T05:19:27-04:00
 ---
 
 PART-1 CONTENT
+
+{{< code-toggle console >}}
+gradle: gradle gatlingEnterpriseStart -Dgatling.enterprise.apiToken=<CREATED_API_TOKEN>
+maven: mvn gatling:enterpriseStart -Dgatling.enterprise.apiToken=<CREATED_API_TOKEN>
+sbt: sbt "Gatling / enterpriseStart" -Dgatling.enterprise.apiToken=<CREATED_API_TOKEN>
+custom: I should not exist!
+{{< /code-toggle >}}
+
+{{< include-code "print-session-value" java kt scala >}}
+
+{{< include-code "ComputerDatabaseSampleJava.java#print-session-value" java >}}

--- a/exampleSite/content/gatling/reference/3.4/_index.md
+++ b/exampleSite/content/gatling/reference/3.4/_index.md
@@ -1,4 +1,4 @@
 ---
 cascade:
-  version: 3.4
+  version: "3.4"
 ---

--- a/exampleSite/content/gatling/reference/3.5/_index.md
+++ b/exampleSite/content/gatling/reference/3.5/_index.md
@@ -1,5 +1,5 @@
 ---
 cascade:
-  version: 3.5
+  version: "3.5"
   latest: true
 ---

--- a/exampleSite/content/gatling/reference/current/_index.md
+++ b/exampleSite/content/gatling/reference/current/_index.md
@@ -1,5 +1,5 @@
 ---
 cascade:
-  version: 3.5
+  version: "3.5"
   latest: true
 ---

--- a/layouts/shortcodes/code-toggle.html
+++ b/layouts/shortcodes/code-toggle.html
@@ -1,20 +1,24 @@
 {{- $syntax := .Get 0 -}}
 {{- $code := .Inner | transform.Unmarshal -}}
-{{- $tools := slice "bundle" "gradle" "maven" "sbt" -}}
+{{- $tools := slice -}}
+{{- range $key, $value := $code -}}
+  {{- $tools = $tools | append $key -}}
+{{- end -}}
 <div class="code-toggle">
+
   <div class="code-toggle-nav">
-    {{ range $tools }}
-      <button data-toggle-key="build-tool" data-toggle-tab="{{ . }}" class="tab-button {{ cond (eq . "bundle") "active" ""}}">
-        {{ . }}
-      </button>
-      &nbsp;
-    {{ end }}
+  {{ range $tools }}
+    <button data-toggle-key="build-tool" data-toggle-value="{{ . }}" class="tab-button">
+      {{ . }}
+    </button>
+  {{ end }}
   </div>
+
   <div class="tab-content">
-    {{ range $tools }}
-      <div data-pane="{{ . }}" class="tab-pane {{ cond (eq . "bundle") "active" ""}}">
-        {{- highlight (index $code .) $syntax "" -}}
-      </div>
-    {{ end }}
+  {{ range $tools }}
+    <div data-toggle-key="build-tool" data-toggle-value="{{ . }}" class="tab-pane">
+      {{- highlight (index $code .) $syntax "" -}}
+    </div>
+  {{ end }}
   </div>
 </div>

--- a/layouts/shortcodes/include-code.html
+++ b/layouts/shortcodes/include-code.html
@@ -98,7 +98,7 @@
 <div class="code-toggle">
   <div class="code-toggle-nav">
     {{- range $language, $content := $code -}}
-    <button data-toggle-key="language" data-toggle-tab="{{ $language }}" class="tab-button {{ cond (eq $language $.Site.Params.includecode.default) "active" ""}}">
+    <button data-toggle-key="language" data-toggle-value="{{ $language }}" class="tab-button">
       {{- if isset $.Site.Params.includecode.labels $language -}}
         {{- index $.Site.Params.includecode.labels $language -}}
       {{- else -}}
@@ -110,7 +110,7 @@
   </div>
   <div class="tab-content">
     {{- range $language, $content := $code -}}
-    <div data-pane="{{ $language }}" class="tab-pane {{ cond (eq $language $.Site.Params.includecode.default) "active" ""}}">
+    <div data-toggle-key="language" data-toggle-value="{{ $language }}" class="tab-pane">
       {{ highlight $content $language "" }}
     </div>
     {{- end -}}


### PR DESCRIPTION
fix: example site version must be a string, not a float
---

chore: add example in example site to test code toggle and include code shortcodes
---

fix: handle properly code-toggle and include-code tabs, closes MISC-383
---

**Motivation:**
When loading default values, all tabs were reset so only last key was correctly set on default values.

**Modification:**
* data-toggle-key is the key for a common choice
* data-toggle-value is the value for the related choice (when changed, all related data-toggle-key are updated)
* refactor tabs behavior based on those changes