### PR TITLE
chore: check anchors exists before rendering links

### DIFF
--- a/layouts/shortcodes/ref.html
+++ b/layouts/shortcodes/ref.html
@@ -1,0 +1,24 @@
+{{- $anchoredPath := .Get 0 -}}
+{{- if strings.Contains $anchoredPath "#" -}}
+  {{- $root := .Page -}}
+  {{- $split := split $anchoredPath "#" -}}
+  {{- $path := index $split 0 -}}
+  {{- $anchor := index $split 1 -}}
+  {{- $page := "" }}
+  {{- if eq $path "" -}}
+    {{- $page = .Page -}}
+  {{- else -}}
+    {{- $page = .Site.GetPage $path -}}
+  {{- end -}}
+  {{- if ne $page.Fragments nil -}}
+    {{- $identifiers := $page.Fragments.Identifiers -}}
+    {{- if not (in $identifiers $anchor) -}}
+      {{- if eq .Parent nil -}}
+        {{- errorf "[%s] REF_NOT_FOUND: Ref %q: %s: anchor not found" $root.Language $anchoredPath .Position -}}
+      {{- else -}}
+        {{- errorf "[%s] REF_NOT_FOUND: Ref %q: %s: anchor not found inside shortcode %s" $root.Language $anchoredPath .Parent.Position .Parent.Name -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- ref . $anchoredPath -}}

--- a/layouts/shortcodes/relref.html
+++ b/layouts/shortcodes/relref.html
@@ -1,0 +1,24 @@
+{{- $anchoredPath := .Get 0 -}}
+{{- if strings.Contains $anchoredPath "#" -}}
+  {{- $root := .Page -}}
+  {{- $split := split $anchoredPath "#" -}}
+  {{- $path := index $split 0 -}}
+  {{- $anchor := index $split 1 -}}
+  {{- $page := "" }}
+  {{- if eq $path "" -}}
+    {{- $page = .Page -}}
+  {{- else -}}
+    {{- $page = .Site.GetPage $path -}}
+  {{- end -}}
+  {{- if ne $page.Fragments nil -}}
+    {{- $identifiers := $page.Fragments.Identifiers -}}
+    {{- if not (in $identifiers $anchor) -}}
+      {{- if eq .Parent nil -}}
+        {{- errorf "[%s] REF_NOT_FOUND: Ref %q: %s: anchor not found" $root.Language $anchoredPath .Position -}}
+      {{- else -}}
+        {{- errorf "[%s] REF_NOT_FOUND: Ref %q: %s: anchor not found inside shortcode %s" $root.Language $anchoredPath .Parent.Position .Parent.Name -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- relref . $anchoredPath -}}


### PR DESCRIPTION
Example output:

```
Change detected, rebuilding site.
2023-10-12 11:59:02.563 +0200
Template changed WRITE         ".../gatling.io-doc-theme/layouts/shortcodes/ref.html"
ERROR [en] REF_NOT_FOUND: Ref "#wrong-anchor": ".../frontline-cloud-doc/content/tutorials/getting-started/index.md:19:1": anchor not found
ERROR [en] REF_NOT_FOUND: Ref "#wrong-anchor": ".../frontline-cloud-doc/content/tutorials/getting-started/index.md:21:1": anchor not found inside shortcode alert
ERROR Rebuild failed: logged 2 error(s)
Total in 29 ms
````