### PR TITLE
fix: use page param to enable swagger CSS

### DIFF
--- a/exampleSite/content/enterprise/cloud/reference/category-1/api/index.md
+++ b/exampleSite/content/enterprise/cloud/reference/category-1/api/index.md
@@ -2,6 +2,7 @@
 title: "API"
 date: 2021-04-23T05:19:27-04:00
 toc: false
+swagger-ui: true
 ---
 
 PART-1 CONTENT

--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -53,7 +53,7 @@
   <script src="{{ $index.Permalink }}" integrity="{{ $index.Data.Integrity }}" crossorigin="anonymous"></script>
 {{ end -}}
 
-{{ if .Page.Scratch.Get "hasOpenApi" -}}
+{{ if .Page.Param "swagger-ui" -}}
   {{ $swaggerUIJS := resources.Get "js/swagger-ui.ts" -}}
   {{ $swaggerUIJS := $swaggerUIJS | babel | js.Build -}}
   {{ if eq (hugo.Environment) "development" -}}

--- a/layouts/partials/head/stylesheet.html
+++ b/layouts/partials/head/stylesheet.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="{{ $secureCSS.Permalink }}" integrity="{{ $secureCSS.Data.Integrity }}" crossorigin="anonymous">
 {{ end -}}
 <noscript><style>img.lazyload { display: none; }</style></noscript>
-{{ if .Page.Scratch.Get "hasOpenApi" -}}
+{{ if .Page.Param "swagger-ui" -}}
   {{ if eq (hugo.Environment) "development" -}}
     {{ $options := (dict "targetPath" "swagger-ui.css" "enableSourceMap" true "includePaths" (slice "node_modules")) -}}
     {{ $css := resources.Get "scss/swagger-ui.scss" | toCSS $options -}}

--- a/layouts/shortcodes/swagger-ui.html
+++ b/layouts/shortcodes/swagger-ui.html
@@ -1,3 +1,6 @@
+{{ if not ( .Page.Param "swagger-ui" ) }}
+  {{ errorf "Cannot use swagger-ui shortcode without swagger-ui parameter in the front matter." }}
+{{ end }}
+
 {{ $original := .Get "src" }}
 <div class="swagger-ui-wrapper" data-openapi-url="{{ $original }}"></div>
-{{ .Page.Scratch.Set "hasOpenApi" true -}}


### PR DESCRIPTION
Motivation:
With .Page.Scratch alone, the CSS is not correctly embedded.

Modifications:
 * Force to use a front matter param to enable swagger-ui shortcode

Result:
To be able to use swagger-ui shortcode we must enable it in the front matter. This way, we can load the CSS.