### PR TITLE
fix: response background (light theme) on Swagger-UI, MISC-440

### DIFF
--- a/assets/scss/swagger-ui.scss
+++ b/assets/scss/swagger-ui.scss
@@ -4,7 +4,7 @@
 
 body.cloud .docs-content .swagger-ui,
 body.enterprise .docs-content .swagger-ui {
-  pre {
+  small > pre {
     background: initial;
   }
 


### PR DESCRIPTION
Ref: MISC-440

Before:

![image](https://github.com/gatling/gatling.io-doc-theme/assets/10268774/8b885b41-6ad2-4442-9ee4-29757ca736dc)


After:
<img width="946" alt="Capture d’écran 2023-11-20 à 16 31 52" src="https://github.com/gatling/gatling.io-doc-theme/assets/10268774/b5431c4a-9ef0-4007-89fe-76068c2be42b">
