### PR TITLE
feat: document how to use badges in titles, allow self-closed form

### DIFF
--- a/assets/scss/components/_badges.scss
+++ b/assets/scss/components/_badges.scss
@@ -29,9 +29,16 @@
 
 h1,
 h2,
-h3 {
+h3,
+h4,
+h5,
+h6 {
   .badge {
     font-size: 0.5em;
     vertical-align: middle;
   }
+}
+
+#TableOfContents .badge {
+  vertical-align: text-bottom;
 }

--- a/exampleSite/content/theme/short-codes/badge/index.md
+++ b/exampleSite/content/theme/short-codes/badge/index.md
@@ -4,15 +4,32 @@ title: Badge
 
 ### Description
 
-Badges, only support *success* at the moment, to add more variants, see `_badges.scss`.
+It's possible to uses badges using a closed form:
 
-```markdown
-{{</* badge success */>}} New {{</* /badge */>}}
+```
+{{</* badge success */>}}New{{</* /badge */>}}
 ```
 
-### Example
+Or even a self-closed form:
 
-{{< badge success >}}
-success
-{{< /badge >}}
+```
+{{</* badge success "New" /*/>}}
+```
 
+### Example 1 {{% badge success %}}closed{{% /badge %}} {#example-1}
+
+For badges in title, use `%%` instead of `<>`:
+
+```
+### Example 1 {{%/* badge success */%}}closed{{%/* /badge */%}} {#example-1}
+```
+
+### Example 2 {{% badge success "self closed" %}}{{% /badge %}} {#example-2}
+
+Or using self-closed form:
+
+```
+### Example 1 {{%/* badge success "self closed" /*/%}} {#example-2}
+```
+
+Note: you want to override the default anchor when using a badge, otherwise the header link will be "weird", e.g: #example-2-span-classbadge-badge-successself-closedspan 

--- a/layouts/shortcodes/badge.html
+++ b/layouts/shortcodes/badge.html
@@ -1,1 +1,5 @@
+{{- if eq (strings.Chomp .Inner) "" -}}
+<span class="badge badge-{{ .Get 0 }}">{{ .Get 1 }}</span>
+{{- else -}}
 <span class="badge badge-{{ .Get 0 }}">{{ .Inner }}</span>
+{{- end -}}


### PR DESCRIPTION
<img width="975" alt="Screenshot 2024-01-16 at 14 04 59" src="https://github.com/gatling/gatling.io-doc-theme/assets/2608594/72843832-4469-48d1-a392-c0c068ff4558">
