### PR TITLE
feat: use custom ordering instead of page weights

### DIFF
--- a/layouts/partials/head/opengraph.html
+++ b/layouts/partials/head/opengraph.html
@@ -1,12 +1,7 @@
 <meta property="og:title" content="{{ .Title }}">
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}">
-{{ if $.Scratch.Get "paginator" -}}
-  {{ $paginator := .Paginate (where .Site.RegularPages.ByDate.Reverse "Section" "tutorials" ) -}}
-  <meta property="og:url" content="{{ .Paginator.URL | absURL }}">
-{{ else -}}
-  <meta property="og:url" content="{{ .Permalink }}">
-{{ end -}}
+<meta property="og:url" content="{{ .Permalink }}">
 
 {{ with $.Params.images -}}
   {{ range first 6 . -}}

--- a/layouts/partials/main/navigation.html
+++ b/layouts/partials/main/navigation.html
@@ -1,9 +1,5 @@
 
-{{- $pages := slice -}}
-{{- range (.Scratch.Get "sections") -}}
-  {{- $pages = $pages | append (where .RegularPagesRecursive "Params.private" "ne" true) -}}
-{{- end -}}
-{{- $pages = $pages.ByWeight -}}
+{{- $pages := .Scratch.Get "pagesByOrdering" -}}
 <div class="docs-navigation d-flex justify-content-between">
   {{ with $pages.Next . -}}
   <a href="{{ .Permalink }}">

--- a/layouts/partials/sidebar/menu.html
+++ b/layouts/partials/sidebar/menu.html
@@ -1,28 +1,48 @@
-{{ range .Scratch.Get "sections" }}
+{{- .Scratch.Set "pagesByOrdering" slice -}}
+{{ range .Scratch.Get "sections" -}}
 <ul class="list-unstyled">
-  {{ template "section-tree-nav" dict "currentnode" $ "depth" 0 "section" . }}
+  {{ template "section-tree-nav" dict "currentPage" $ "depth" 0 "page" . "scratch" $.Scratch }}
 </ul>
-{{ end }}
+{{- end }}
 
 {{ define "section-tree-nav" }}
-  {{ $currentNode := .currentnode }}
-  {{ $depth := .depth }}
-  {{ with .section }}
-    {{ $splitPermalink := split (trim .RelPermalink "/") "/" }}
-    {{ $sectionName := index (last 1 $splitPermalink) 0 }}
+  {{- $currentPage := .currentPage -}}
+  {{- $depth := .depth -}}
+  {{- $scratch := .scratch -}}
+  {{ with .page -}}
+    {{- if .IsPage -}}{{- $scratch.Add "pagesByOrdering" . -}}{{- end -}}
     {{ if gt $depth 0 }}<li>{{ end }}
-      <a class="docs-link{{ if in $currentNode.RelPermalink .RelPermalink }} active{{ end }}" title="{{ .Title }}" {{ if and .IsSection (gt $depth 0) }}href="#collapsable-{{ .File.UniqueID }}" data-toggle="collapse" role="button" aria-expanded="{{ .IsAncestor $currentNode }}" aria-controls="collapsable-{{ .File.UniqueID }}"{{ else }}href="{{ .RelPermalink }}"{{ end }}>
-        {{ if eq $depth 0 }}<h3>{{ else }}{{ if and (.IsAncestor $currentNode) (not (eq $currentNode .)) }}<i class="fas fa-chevron-down"></i> {{ else if .IsSection }}<i class="fas fa-chevron-right"></i> {{ end }}{{ end }}{{ .Title }}{{ with .Params.badge }} <span class="badge badge-{{ .type }}">{{ .label }}</span>{{ end }}{{ if eq $depth 0 }}</h3>{{ end }}
+      <a class="docs-link{{ if in $currentPage.RelPermalink .RelPermalink }} active{{ end }}" title="{{ .Title }}" {{ if and .IsSection (gt $depth 0) }}href="#collapsable-{{ .File.UniqueID }}" data-toggle="collapse" role="button" aria-expanded="{{ .IsAncestor $currentPage }}" aria-controls="collapsable-{{ .File.UniqueID }}"{{ else }}href="{{ .RelPermalink }}"{{ end }}>
+        {{ if eq $depth 0 }}<h3>{{ else }}{{ if and (.IsAncestor $currentPage) (not (eq $currentPage .)) }}<i class="fas fa-chevron-down"></i> {{ else if .IsSection }}<i class="fas fa-chevron-right"></i> {{ end }}{{ end }}{{ .Title }}{{ if eq $depth 0 }}</h3>{{ end }}
       </a>
-      {{ if .IsSection }}
-        <ul {{ if gt $depth 0 }}id="collapsable-{{ .File.UniqueID }}"{{ end }} class="list-unstyled{{ if and (gt $depth 0) (not (.IsAncestor $currentNode)) }} collapse{{ end }}">
-          {{ range (.Pages | union .Sections).ByWeight }}
-            {{ if ne .Params.private true }}
-              {{ template "section-tree-nav" dict "currentnode" $currentNode "depth" (add $depth 1) "section" . }}
-            {{ end }}
-          {{ end }}
+      {{ if .IsSection -}}
+        <ul {{ if gt $depth 0 }}id="collapsable-{{ .File.UniqueID }}"{{ end }} class="list-unstyled{{ if and (gt $depth 0) (not (.IsAncestor $currentPage)) }} collapse{{ end }}">
+          {{- $page := . -}}
+          {{- $children := $page.Pages | union $page.Sections -}}
+          {{- $ordering := slice -}}
+          {{- if isset .Params "ordering" -}}
+            {{- range .Params.ordering -}}
+              {{- if or (eq . nil) (eq . "") -}}
+                {{- errorf "[%s] REF_NOT_FOUND: ordering propery has a nil or empty value in file %s" $page.Language $page.File -}}
+              {{- end -}}
+              {{- $child := $page.GetPage . -}}
+              {{- if eq $child.Parent nil -}}
+                {{- errorf "[%s] REF_NOT_FOUND: %q is referenced in the ordering property of the page %q but was not found" $page.Language . $page.File -}}
+              {{ else }}
+                {{- $ordering = $ordering | append $child -}}
+              {{ end }}
+            {{- end -}}
+            {{- range (complement $ordering $children) -}}
+              {{- errorf "[%s] REF_NOT_FOUND: %q is not referenced in the ordering property of its parent page in file %q" $page.Language .File.ContentBaseName .Parent.File -}}
+            {{- end -}}
+            {{- range $ordering -}}
+              {{- template "section-tree-nav" dict "currentPage" $currentPage "depth" (add $depth 1) "page" . "scratch" $scratch -}}
+            {{- end -}}
+          {{- else -}}
+            {{- errorf "[%s] REF_NOT_FOUND: missing ordering property in file %q" $page.Language $page.File -}}
+          {{- end -}}
         </ul>
-      {{ end }}
+      {{- end }}
     {{ if gt $depth 0 }}</li>{{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Motivation:

Weights are used for ordering the left menu and the inner navigation (i.e.: prev/next button on the bottom).

For the left menu, as a sort is performed on the children of a node, making it hard to mess up the hierarchy. For the bottom navigation, all pages are sorted independently of the hierarchy, making it really easy to mess up the navigation.

Weights are rightfully hard to maintain and as a consequence rarely are. -> Turns out ordering are maintained even though they have no actual use "yet" -> Make use of the ordering property for sorting instead of the weights

Modification:

- Use the ordering for both the left navigation menu and the next/prev one
- While going through the doc hierarchy and making the left menu, record the ordering of the pages
- Use this ordering for prev/next navigation on the bottom of the pages
- Print errors if: a page is referenced in the ordering but does that actually exists, a page exists but is missing from the ordering
- SEO paginator being unused, remove it

Result:

- All weights can now be removed