### PR TITLE
feat: keep original order of supported languages, add a 'not supported' warning on code toggles

### DIFF
--- a/assets/scss/components/_alerts.scss
+++ b/assets/scss/components/_alerts.scss
@@ -167,6 +167,10 @@
   border-left: 0.3em solid #ffc919;
 }
 
+.code-toggle-nav .tab-button.warning.active {
+  background-color: #ffc9191a;
+}
+
 .alert-warning::before {
   background-color: #ffc919;
   background-image: url($baseUrl + "/images/alerts/exclamation-solid.svg");

--- a/layouts/shortcodes/include-code.html
+++ b/layouts/shortcodes/include-code.html
@@ -1,12 +1,21 @@
-{{- if isset .Site.Params "includecode" -}}
-  {{- if not (isset .Site.Params.includecode "default") -}}
-    {{- errorf "%s: missing parameter includeCode.default, check params.yml" .Position -}}
+{{- if isset .Site.Params "languages" -}}
+  {{- if not (isset .Site.Params.languages "default") -}}
+    {{- errorf "%s: missing parameter languages.default, check params.yml" .Position -}}
   {{- end -}}
-  {{- if not (isset .Site.Params.includecode "labels") -}}
-    {{- errorf "%s: missing parameter includeCode.labels, check params.yml" .Position -}}
+  {{- if not (isset .Site.Params.languages "labels") -}}
+    {{- errorf "%s: missing parameter languages.labels, check params.yml" .Position -}}
   {{- end -}}
 {{- else -}}
-  {{- errorf "%s: missing parameter includeCode, check params.yml" .Position -}}
+  {{- errorf "%s: missing parameter languages, check params.yml" .Position -}}
+{{- end -}}
+
+{{- $labels := dict -}}
+{{- $ordering := slice -}}
+{{- range .Site.Params.languages.labels -}}
+  {{- range $language, $label := . -}}
+    {{- $labels = merge $labels (dict $language $label) -}}
+    {{- $ordering = $ordering | append $language -}}
+  {{- end -}}
 {{- end -}}
 
 {{- $pathWithAnchorTag := (.Get 0) -}}
@@ -27,7 +36,7 @@
 
 {{- $languages := slice -}}
 {{- if eq (len .Params) 1 -}}
-  {{- $languages = $languages | append .Site.Params.includecode.default }}
+  {{- $languages = append $languages $ordering -}}
 {{- else -}}
   {{- if and (in $path ".") (gt (len .Params) 2) -}}
     {{- warnf "%s: shouldn't specify file extension with multiple languages" .Position -}}
@@ -91,16 +100,18 @@
 {{- end -}}
 
 {{- if eq (len $code) 1 -}}
-{{- range $language, $content := $code -}}
-{{- highlight $content $language "" -}}
-{{- end -}}
+  {{- range $language, $content := $code -}}
+    {{- highlight $content $language "" -}}
+  {{- end -}}
 {{- else -}}
 <div class="code-toggle">
   <div class="code-toggle-nav">
-    {{- range $language, $content := $code -}}
-    <button data-toggle-key="language" data-toggle-value="{{ $language }}" class="tab-button">
-      {{- if isset $.Site.Params.includecode.labels $language -}}
-        {{- index $.Site.Params.includecode.labels $language -}}
+    {{- range $languages -}}
+    {{- $language := . -}}
+    {{- $content := index $code . -}}
+    <button data-toggle-key="language" data-toggle-value="{{ $language }}" class="tab-button{{ if eq $content "NOT SUPPORTED" }} warning{{ end}}">
+      {{- if isset $labels $language -}}
+        {{- index $labels $language -}}
       {{- else -}}
         {{- $language -}}
       {{- end -}}
@@ -109,9 +120,17 @@
     {{- end -}}
   </div>
   <div class="tab-content">
-    {{- range $language, $content := $code -}}
+    {{- range $languages -}}
+    {{- $language := . -}}
+    {{- $content := index $code . -}}
     <div data-toggle-key="language" data-toggle-value="{{ $language }}" class="tab-pane">
-      {{ highlight $content $language "" }}
+      {{- if eq $content "NOT SUPPORTED" -}}
+      <div class="alert alert-warning" style="margin-top:0">
+        <div class="w-100">Not supported by Gatling JS.</div>
+      </div>
+      {{- else -}}
+      {{- highlight $content $language "" -}}
+      {{- end -}}
     </div>
     {{- end -}}
   </div>


### PR DESCRIPTION
Original code-toggle sorted supported languages by "key", forcing "js" between "java" and "kt". This PR aims to fix that, renaming the parameters while we're at it:

From:

```yaml
includeCode:
  default: java
  labels:
    java: Java
    kt: Kotlin
    scala: Scala
```

To:

```
languages:
  default: java
  labels:
    - java: Java
    - kt: Kotlin
    - scala: Scala
    - js: JavaScript
```

Also, it introduces a warning for non supported methods/functions/etc. It requires putting "NOT SUPPORTED" between the comments (wrapped with multilines comments so it compiles inside the host language):

```
/*
//#response-processors
NOT SUPPORTED
//#response-processors
*/
```

Which looks like:

<img width="773" alt="Screenshot 2024-05-15 at 08 22 29" src="https://github.com/gatling/gatling.io-doc-theme/assets/2608594/1f43d996-c995-433d-bdb1-d7c9d4ba4202">
