### PR TITLE
feat: synchronize between similar code toggles by key

### DIFF
--- a/assets/js/tabs.ts
+++ b/assets/js/tabs.ts
@@ -3,6 +3,8 @@ const DATA_TOGGLE_VALUE = "data-toggle-value";
 
 const ACTIVE_CLASS = "active";
 
+const RANDOMIZED_DATA_PREFIX = "code-toggle-";
+
 const selectTabEvent = (targetKey: string, targetValue: string) => {
   document.querySelectorAll(`[${DATA_TOGGLE_KEY}='${targetKey}']`).forEach(selected => {
     selected.classList.remove(ACTIVE_CLASS);
@@ -10,25 +12,21 @@ const selectTabEvent = (targetKey: string, targetValue: string) => {
       selected.classList.add(ACTIVE_CLASS);
     }
   })
-}
+};
 
-const DEFAULTS_TABS = {
+const TABS_DEFAULTS = {
   "build-tool": "maven",
-  "language": "java"
-}
+  "language": "java",
+  "platform": window.navigator.platform.indexOf("Win") !== -1 ? "Windows" : "Linux/MacOS"
+};
 
 const toggleAllTabsOnClick = (targetKey: string, targetValue: string) => {
-  if (targetKey in DEFAULTS_TABS) {
-    // We store the config language selected in users' localStorage
-    localStorage.setItem(targetKey, targetValue);
-
-    if (targetKey === "language") {
-      if (window.gtag !== undefined && window.languages !== undefined && window.languages.hasOwnProperty(targetValue)) {
-        window.gtag("event", "Language toggle clicked", {
-          event_category: "Documentation DSL",
-          event_label: window.languages[targetValue],
-        });
-      }
+  if (targetKey === "language") {
+    if (window.gtag !== undefined && window.languages !== undefined && window.languages.hasOwnProperty(targetValue)) {
+      window.gtag("event", "Language toggle clicked", {
+        event_category: "Documentation DSL",
+        event_label: window.languages[targetValue],
+      });
     }
   }
 
@@ -38,19 +36,20 @@ const toggleAllTabsOnClick = (targetKey: string, targetValue: string) => {
 for (const tab of document.querySelectorAll(`button[${DATA_TOGGLE_KEY}]`)) {
   tab.addEventListener("click", (event) => {
     event.preventDefault();
-    toggleAllTabsOnClick(
-      event.currentTarget.getAttribute(DATA_TOGGLE_KEY),
-      event.currentTarget.getAttribute(DATA_TOGGLE_VALUE)
-    )
+
+    const targetKey = event.currentTarget.getAttribute(DATA_TOGGLE_KEY);
+    const targetValue = event.currentTarget.getAttribute(DATA_TOGGLE_VALUE);
+    toggleAllTabsOnClick(targetKey, targetValue);
+
+    if (!targetKey.startsWith(RANDOMIZED_DATA_PREFIX)) {
+      // We store the config selected in users' localStorage
+      localStorage.setItem(targetKey, targetValue);
+    }
   });
 }
 
-// Clean up old items
-if (localStorage.hasOwnProperty("configLangPref")) {
-  localStorage.removeItem("configLangPref");
-}
-
-for (const [key, defaultValue] of Object.entries(DEFAULTS_TABS)) {
+for (const [key, defaultValue] of Object.entries(TABS_DEFAULTS)) {
   const value = localStorage.getItem(key) ?? defaultValue;
+
   selectTabEvent(key, value);
 }

--- a/assets/scss/components/_code.scss
+++ b/assets/scss/components/_code.scss
@@ -50,7 +50,6 @@ pre code {
   border-radius: 0.25rem;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
-  margin-bottom: -1px;
   outline: none;
   padding: 0.625rem 0.75rem;
   position: relative;

--- a/layouts/shortcodes/code-toggle.html
+++ b/layouts/shortcodes/code-toggle.html
@@ -1,24 +1,30 @@
-{{- $syntax := .Get 0 -}}
 {{- $code := .Inner | transform.Unmarshal -}}
-{{- $tools := slice -}}
+{{- $values := slice -}}
 {{- range $key, $value := $code -}}
-  {{- $tools = $tools | append $key -}}
+  {{- $values = $values | append $key -}}
 {{- end -}}
+
+{{- $key := "undefined" }}
+{{- if .Get "key" -}}
+  {{- $key = .Get "key" -}}
+{{- else -}}
+  {{- .Page.Scratch.Add "code-toggle" 1 -}}
+  {{- $n := .Page.Scratch.Get "code-toggle" -}}
+  {{- $key = printf "code-toggle-%03d" $n -}}
+{{- end -}}
+
 <div class="code-toggle">
-
   <div class="code-toggle-nav">
-  {{ range $tools }}
-    <button data-toggle-key="build-tool" data-toggle-value="{{ . }}" class="tab-button">
-      {{ . }}
-    </button>
-  {{ end }}
+  {{ range $index, $value := $values -}}
+    <button data-toggle-key="{{ $key }}" data-toggle-value="{{ $value }}" class="tab-button{{ if eq $index 0 }} active{{ end }}">{{ $value }}</button>
+    &nbsp;
+  {{- end }}
   </div>
-
   <div class="tab-content">
-  {{ range $tools }}
-    <div data-toggle-key="build-tool" data-toggle-value="{{ . }}" class="tab-pane">
-      {{- highlight (index $code .) $syntax "" -}}
+  {{ range $index, $value := $values -}}
+    <div data-toggle-key="{{ $key }}" data-toggle-value="{{ $value }}" class="tab-pane{{ if eq $index 0 }} active {{ end }}">
+      {{- highlight (index $code .) "console" "" -}}
     </div>
-  {{ end }}
+  {{- end }}
   </div>
 </div>


### PR DESCRIPTION
Motivation:

- Currently, only "languages" toggle are synchronized through the include-code shortcode
- Most code-toggle are used for platform related commands but are not synchronized and always default to Linux/MacOS

Modification:

- Replace the formatting argument of code-toggle by a key that means "synchronize this code-toggle with others that share the same key"
- If no key is specified, generated a unique id (per page) for this code-toggle to make it independant
- If the key is was generated, it will be remembered to later page views
- Choose a default value for the platform key that depends on the actual user platform