### PR TITLE
Remove link cards from the homepage

### DIFF
--- a/layouts/partials/list/default.html
+++ b/layouts/partials/list/default.html
@@ -1,6 +1,6 @@
 <h1 class="text-left">{{ .Title }}</h1>
 <div class="text-left">{{ .Content }}</div>
-<div class="card-list">
+<!-- <div class="card-list">
   {{- $page := . -}}
   {{ range .Params.ordering -}}
     {{- with ($page.GetPage .) -}}
@@ -16,4 +16,4 @@
     </div>
     {{- end -}}
   {{- end }}
-</div>
+</div> -->


### PR DESCRIPTION
The link cards were redundant content. 
- This change should be merged just before the docs reorg PR
Partial view of ToC on mobile after the change:
<img width="450" alt="Capture d’écran 2025-05-26 à 14 25 24" src="https://github.com/user-attachments/assets/25a16d41-f8e4-4155-9071-228b028e9dca" />
</br>
New homepage links: 
<img width="954" alt="Capture d’écran 2025-05-26 à 14 26 21" src="https://github.com/user-attachments/assets/b63c8917-dccb-4852-9a8c-953d3d1ec8a3" />
