### PR TITLE
Suppress card-list

### DIFF
--- a/layouts/partials/list/default.html
+++ b/layouts/partials/list/default.html
@@ -1,19 +1,22 @@
 <h1 class="text-left">{{ .Title }}</h1>
 <div class="text-left">{{ .Content }}</div>
-<div class="card-list">
-  {{- $page := . -}}
-  {{ range .Params.ordering -}}
-    {{- with ($page.GetPage .) -}}
-    <div class="card my-4">
-      <div class="card-body">
-        <a class="stretched-link" href="{{ .Permalink }}">
-          {{ .Params.title }}
-        </a>
-        {{ if isset .Params "lead" -}}
-          <small>{{ .Params.lead }}</small>
-        {{- end }}
-      </div>
-    </div>
-    {{- end -}}
-  {{- end }}
-</div>
+{{ if not .IsHome }}
+  <div class="card-list">
+    {{- $page := . -}}
+    {{ range .Params.ordering -}}
+      {{- with ($page.GetPage .) -}}
+        <div class="card my-4">
+          <div class="card-body">
+            <a class="stretched-link" href="{{ .Permalink }}">
+              {{ .Params.title }}
+            </a>
+            {{ if isset .Params "lead" -}}
+              <small>{{ .Params.lead }}</small>
+            {{- end }}
+          </div>
+        </div>
+      {{- end -}}
+    {{- end }}
+  </div>
+{{ end }}
+


### PR DESCRIPTION
Suppress card-list only on the homepage
- uses `isHome` to remove the card list on the homepage, but preserve it on the section pages:
<img width="1049" alt="Capture d’écran 2025-05-27 à 12 23 07" src="https://github.com/user-attachments/assets/7cc13d4c-ae56-4e77-af9f-cf65f23dc288" />
</br>
<img width="1432" alt="Capture d’écran 2025-05-27 à 12 22 43" src="https://github.com/user-attachments/assets/34058aaa-9df3-45f4-9f9e-4b11c65b16fe" />


 