### PR TITLE
feat: hide schemas in swagger UI

### DIFF
--- a/assets/js/swagger-ui.ts
+++ b/assets/js/swagger-ui.ts
@@ -8,6 +8,7 @@ document.querySelectorAll<HTMLElement>(".swagger-ui-wrapper").forEach((swaggerEl
     presets: [
       SwaggerUIBundle.presets.apis,
       SwaggerUIStandalonePreset
-    ]
+    ],
+    defaultModelsExpandDepth: -1
   });
 });


### PR DESCRIPTION
Motivation:
Takes too much space

Modifications:
Hide the schemas by default

Result:
The schemas will be hidden

<img width="1514" height="623" alt="image" src="https://github.com/user-attachments/assets/4feac358-fb67-4c8a-8618-2ab1df4e3c18" />
