### PR TITLE
feat: remove tables margin

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -38,7 +38,6 @@ $fa-font-path: $baseUrl + "/webfonts";
 @import "components/menu";
 @import "components/search";
 @import "components/syntax";
-@import "components/tables";
 @import "components/youtube";
 
 @import "docsearch/variables";

--- a/assets/scss/components/_tables.scss
+++ b/assets/scss/components/_tables.scss
@@ -1,5 +1,0 @@
-table {
-  @extend .table;
-
-  margin: 3rem 0;
-}


### PR DESCRIPTION
Tables margins are currently a bit over the top:

<img width="977" height="277" alt="Screenshot 2026-02-20 at 18 28 40" src="https://github.com/user-attachments/assets/111c90ab-054c-49dc-a6e1-80fff2221f8c" />

Now:

<img width="978" height="347" alt="Screenshot 2026-02-20 at 18 29 38" src="https://github.com/user-attachments/assets/f921f212-3e26-4290-a059-3300e158f795" />
