### PR TITLE
fix: put the mermaid script in the footer

### DIFF
--- a/layouts/partials/footer/script-footer.html
+++ b/layouts/partials/footer/script-footer.html
@@ -32,6 +32,11 @@
   <script src="{{ $main.Permalink }}" integrity="{{ $main.Data.Integrity }}" crossorigin="anonymous" defer></script>
 {{ end -}}
 
+{{ if and (.Store.Get "hasMermaid") (isset .Site.Params "mermaid") (isset .Site.Params.mermaid "moduleurl") -}}
+{{- $mermaidInit := resources.Get "js/mermaid-init.js" | resources.ExecuteAsTemplate "mermaid-init.js" . -}}
+<script type="module">{{ $mermaidInit.Content | safeJS }}</script>
+{{- end }}
+
 {{ if .Page.Param "swagger-ui" -}}
   {{ $swaggerUIJS := resources.Get "js/swagger-ui.ts" -}}
   {{ $swaggerUIJS := $swaggerUIJS | babel | js.Build -}}

--- a/layouts/partials/head/script-header.html
+++ b/layouts/partials/head/script-header.html
@@ -1,6 +1,2 @@
 {{ $darkModeInit := resources.Get "js/darkmode-init.ts" | babel (dict "minified" true) -}}
 <script>{{ $darkModeInit.Content | safeJS }}</script>
-{{ if and (.Store.Get "hasMermaid") (isset .Site.Params "mermaid") (isset .Site.Params.mermaid "moduleurl") -}}
-{{- $mermaidInit := resources.Get "js/mermaid-init.js" | resources.ExecuteAsTemplate "mermaid-init.js" . -}}
-<script type="module">{{ $mermaidInit.Content | safeJS }}</script>
-{{- end }}


### PR DESCRIPTION
Given the flag is set while producing the HTML, catching the flag to set up the script can only be done at the end of the HTML generation.