### PR TITLE
feat: add `lang` parameter to shortcode `code-toggle`

### DIFF
--- a/layouts/partials/shortcodes/code-toggle.html
+++ b/layouts/partials/shortcodes/code-toggle.html
@@ -1,4 +1,5 @@
 {{- $key := .key }}
+{{- $lang := .lang | default "console" -}}
 {{- $code := .inner | transform.Unmarshal -}}
 {{- $values := slice -}}
 {{- range $key, $value := $code -}}
@@ -15,7 +16,7 @@
   <div class="tab-content">
   {{ range $index, $value := $values -}}
     <div data-toggle-key="{{ $key }}" data-toggle-value="{{ $value }}" class="tab-pane{{ if eq $index 0 }} active {{ end }}">
-      {{- highlight (index $code .) "console" "" -}}
+      {{- highlight (index $code .) $lang "" -}}
     </div>
   {{- end }}
   </div>

--- a/layouts/shortcodes/code-toggle.html
+++ b/layouts/shortcodes/code-toggle.html
@@ -7,4 +7,9 @@
   {{- $key = printf "code-toggle-%03d" $n -}}
 {{- end -}}
 
-{{- partial "shortcodes/code-toggle" (dict "inner" .InnerDeindent "key" $key) -}}
+{{- $lang := "console" -}}
+{{- if .Get "lang" -}}
+  {{- $lang = .Get "lang" -}}
+{{- end -}}
+
+{{- partial "shortcodes/code-toggle" (dict "inner" .InnerDeindent "key" $key "lang" $lang) -}}


### PR DESCRIPTION
**Motivation**:
`code-toggle` set lang to console, we would like to allow custom lang.

**Modification:**
Add `lang` parameter to shortcode `code-toggle`

**Result:**
Lang can be configured `{{< code-toggle lang="hcl" >}}`