### PR TITLE
fix: cards color broke after bootstrap update

### DIFF
--- a/assets/scss/components/_cards.scss
+++ b/assets/scss/components/_cards.scss
@@ -35,3 +35,11 @@
     }
   }
 }
+
+.card {
+  --bs-card-color: $gray-700;
+}
+
+[data-dark-mode] .card {
+  --bs-card-color: #aaa;
+}

--- a/assets/scss/components/_colors.scss
+++ b/assets/scss/components/_colors.scss
@@ -22,13 +22,3 @@ body {
     color: #f78557;
   }
 }
-
-/* Default */
-
-body .card-list a {
-  color: $gray-700 !important;
-}
-
-[data-dark-mode] body .card-list a {
-  color: #aaa !important;
-}


### PR DESCRIPTION
<img width="684" height="687" alt="Screenshot 2026-06-16 at 10 56 55" src="https://github.com/user-attachments/assets/9a2f6dc1-5a65-4ec1-b072-f5a44c84e185" />

<img width="681" height="687" alt="Screenshot 2026-06-16 at 10 57 12" src="https://github.com/user-attachments/assets/c1f0be96-f42b-47f6-81e4-f0d9be7dbb30" />

<img width="675" height="216" alt="Screenshot 2026-06-16 at 11 01 24" src="https://github.com/user-attachments/assets/d1a548d2-fa46-4119-81d9-df20bd893df7" />

<img width="681" height="222" alt="Screenshot 2026-06-16 at 11 01 38" src="https://github.com/user-attachments/assets/a6ea7b47-eb19-4375-9f23-84ec213f0a21" />
