### PR TITLE
feat: apply new app colors to the search button

### DIFF
--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -5,6 +5,7 @@ $baseUrl: "{{ strings.TrimRight "/" .Site.BaseURL }}";
 
 /** Import theme variables */
 @import "common/variables";
+@import "themes/root";
 
 /** Import Bootstrap */
 @import "bootstrap/scss/bootstrap";

--- a/assets/scss/common/_colors.scss
+++ b/assets/scss/common/_colors.scss
@@ -40,4 +40,3 @@ $link-color: $primary;
 $border-color: $gray-200;
 
 $card-border-color: $gray-200;
-

--- a/assets/scss/components/_buttons.scss
+++ b/assets/scss/components/_buttons.scss
@@ -5,27 +5,24 @@
 }
 
 #docSearchToggle {
-  background-color: #f8f9fa;
-  border-color: #dee2e6;
+  background: linear-gradient(0deg, var(--gatling-color-button-primary-background), var(--gatling-color-button-primary-background)) padding-box, var(--gatling-color-button-primary-border) border-box;
+  border: 1px solid transparent;
+  color: var(--gatling-color-button-primary-text);
+  position: relative;
 
   &:hover {
-    border-color: #aaa;
-    color: #aaa;
+    background: var(--gatling-color-button-primary-background-hover) padding-box, var(--gatling-color-button-primary-border) border-box;
+  }
+
+  svg {
+    color: var(--gatling-color-button-primary-prefix-icon);
   }
 
   .docsearch-ask-ai {
-    -webkit-text-fill-color: transparent;
-    background-image: linear-gradient(90deg, #4557dd, #f861ee 50%, #ff763c);
-    background-clip: text;
-
     svg {
-      color: #ff763c;
+      fill: var(--gatling-color-button-primary-prefix-icon);
     }
   }
-}
-
-[data-dark-mode] #docSearchToggle {
-  background-color: #1b1f22;
 }
 
 .btn-link:focus {

--- a/assets/scss/themes/_commons.scss
+++ b/assets/scss/themes/_commons.scss
@@ -1,0 +1,11 @@
+// Black color
+$color-black: #1f2024;
+
+// White color
+$color-white: #fff;
+
+// Gradient
+$color-brand-accent-1: #fd6f7a;
+$color-brand-accent-2: #f861ee;
+$color-brand-accent-3: #4457dd;
+$color-brand-horizontal-gradient: linear-gradient(90deg, $color-brand-accent-1 0%, $color-brand-accent-2 30%, $color-brand-accent-3 80%, $color-brand-accent-3 100%);

--- a/assets/scss/themes/_dark.scss
+++ b/assets/scss/themes/_dark.scss
@@ -1,0 +1,3 @@
+@import "commons";
+
+$dark-color-brand-horizontal-gradient-60: linear-gradient(90deg, darken($color-brand-accent-1, 60%), darken($color-brand-accent-2, 60%), darken($color-brand-accent-3, 60%));

--- a/assets/scss/themes/_light.scss
+++ b/assets/scss/themes/_light.scss
@@ -1,0 +1,4 @@
+@import "commons";
+
+// Gradient
+$light-color-brand-horizontal-gradient-10: linear-gradient(90deg, #fff6f4, #fef5fd, #f4f5fc);

--- a/assets/scss/themes/root.scss
+++ b/assets/scss/themes/root.scss
@@ -1,0 +1,17 @@
+@import "commons";
+@import "light";
+@import "dark";
+
+:root {
+  --gatling-color-button-primary-background: #{$color-white};
+  --gatling-color-button-primary-background-hover: #{$light-color-brand-horizontal-gradient-10};
+  --gatling-color-button-primary-border: #{$color-brand-horizontal-gradient};
+  --gatling-color-button-primary-prefix-icon: #{$color-brand-accent-1};
+  --gatling-color-button-primary-text: #{$color-black};
+}
+
+:root[data-dark-mode] {
+  --gatling-color-button-primary-background: #1b1f22;
+  --gatling-color-button-primary-background-hover: #{$dark-color-brand-horizontal-gradient-60};
+  --gatling-color-button-primary-text: #{$color-white};
+}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -24,21 +24,18 @@
       </span>
       <span class="d-none d-sm-block">
         <span class="docsearch-ask-ai">
-          Ask AI
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="1.3" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"></path>
-            <path d="M20 3v4"></path>
-            <path d="M22 5h-4"></path>
-            <path d="M4 17v2"></path>
-            <path d="M5 18H3"></path>
+          <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24" class="injected-svg" data-src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij4KICAgIDxwYXRoIGNsYXNzPSJmaWxsLWNvbG9yLTEiIGQ9Ik0xOSA5bDEuMjUtMi43NUwyMyA1bC0yLjc1LTEuMjVMMTkgMWwtMS4yNSAyLjc1TDE1IDVsMi43NSAxLjI1TDE5IDl6bS03LjUuNUw5IDQgNi41IDkuNSAxIDEybDUuNSAyLjVMOSAyMGwyLjUtNS41TDE3IDEybC01LjUtMi41ek0xOSAxNWwtMS4yNSAyLjc1TDE1IDE5bDIuNzUgMS4yNUwxOSAyM2wxLjI1LTIuNzVMMjMgMTlsLTIuNzUtMS4yNUwxOSAxNXoiLz4KPC9zdmc+" xmlns:xlink="http://www.w3.org/1999/xlink" role="img">
+            <path class="fill-color-1" d="M19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z"></path>
           </svg>
+          Ask AI
         </span>
-        or search docs
+        or
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
           <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
           <circle cx="10" cy="10" r="7"></circle>
           <line x1="21" y1="21" x2="15" y2="15"></line>
         </svg>
+        search docs
       </span>
     </button>
     {{ end -}}


### PR DESCRIPTION
Reused the original colors from the new app branding but:

- Didn't use the `@use`/`@forward` + `#{light.` syntax because that would require migrating to dartsass (and Hugo requires a global install right now...)
- Change the icons order the max what we do in the app
- Had to improvise for the dark theme.

Light:

<img width="300" height="80" alt="Screenshot 2026-07-20 at 11 28 26" src="https://github.com/user-attachments/assets/62bb41b5-00fe-4374-bae9-3eb7b00b564b" />

Light:hover:

<img width="290" height="73" alt="Screenshot 2026-07-20 at 11 29 04" src="https://github.com/user-attachments/assets/bd6e9b66-556a-4310-adfc-e331f7c465ed" />

Dark:

<img width="289" height="67" alt="Screenshot 2026-07-20 at 11 35 01" src="https://github.com/user-attachments/assets/26ec58e3-1472-4434-bc51-568059443e38" />

Dark:hover:

<img width="297" height="75" alt="Screenshot 2026-07-20 at 11 35 16" src="https://github.com/user-attachments/assets/d95ae96a-2640-4460-b77d-b0286f0c3ad0" />
