### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,13 +12,15 @@ updates:
       # Upgrade to v7 is non-trivial, including changing the Sass compiler required (see https://docs.fontawesome.com/upgrade/scss).
       # It's probably better to wait to handle this with the future upgrade of the base theme.
       - dependency-name: "@fortawesome/fontawesome-free"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
       # Upgrade to v4 causes "Could not resolve "jquery/dist/jquery.min.js" error during site generation (but apparently
       # not when running the dev server?). Possibly something to do with jQuery migrating to ESM.
       # It's probably better to wait to handle this with the future upgrade of the base theme.
       - dependency-name: "jquery"
-        update-types: [ "version-update:semver-major" ]
+        update-types: ["version-update:semver-major"]
     schedule:
       interval: "weekly"
       day: "monday" # explicit, even though it's the weekly default
       time: "07:00" # UTC
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Delays Dependabot version updates by 7 days after a new release is
published. This reduces exposure to supply-chain attacks (malicious
or compromised packages are typically caught and pulled within days
of publication) and supports SOC 2 change-management controls around
vetted, non-immediate dependency updates.

Adds a `cooldown: default-days: 7` block to each `updates` entry in
`.github/dependabot.yml`. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/reducing-the-number-of-pull-requests-dependabot-opens#configuring-cooldown-options
